### PR TITLE
fix(PICMid/Asm): Incorrect operand parsing

### DIFF
--- a/llvm/lib/Target/PICMid/AsmParser/PICMidAsmParser.cpp
+++ b/llvm/lib/Target/PICMid/AsmParser/PICMidAsmParser.cpp
@@ -179,7 +179,7 @@ public:
   }
 
   bool ParseOperand(OperandVector &Operands) {
-    return !(ParseRegister(Operands) && ParseImmediate(Operands));
+    return (ParseImmediate(Operands) && ParseRegister(Operands));
   }
 };
 

--- a/llvm/test/MC/PICMid/add.s
+++ b/llvm/test/MC/PICMid/add.s
@@ -1,5 +1,0 @@
-// RUN: llvm-mc -arch=picmid -show-inst %s | FileCheck %s
-
-    addlw 69
-// CHECK: <MCInst #{{[0-9]+}} ADD
-// CHECK-NEXT: <MCOperand Imm:69>

--- a/llvm/test/MC/PICMid/allInstructions.s
+++ b/llvm/test/MC/PICMid/allInstructions.s
@@ -1,0 +1,21 @@
+; RUN: llvm-mc -arch=picmid -show-inst %s | FileCheck %s -DCURR_FILE=%s
+
+addwf 69, 1
+; CHECK: <MCInst #{{[0-9]+}} ADDWF
+; CHECK-NEXT: <MCOperand Imm:69>
+; CHECK-NEXT: <MCOperand Imm:1>>
+ADDWF 69, 1
+; CHECK: <MCInst #{{[0-9]+}} ADDWF
+; CHECK-NEXT: <MCOperand Imm:69>
+; CHECK-NEXT: <MCOperand Imm:1>>
+andwf 69, 1
+; CHECK: <MCInst #{{[0-9]+}} ANDWF
+; CHECK-NEXT: <MCOperand Imm:69>
+; CHECK-NEXT: <MCOperand Imm:1>>
+ANDWF 69, 1
+; CHECK: <MCInst #{{[0-9]+}} ANDWF
+; CHECK-NEXT: <MCOperand Imm:69>
+; CHECK-NEXT: <MCOperand Imm:1>>
+CLRF 127 
+; CHECK: <MCInst #{{[0-9]+}} CLRF
+; CHECK-NEXT: <MCOperand Imm:127>>


### PR DESCRIPTION
Prior to this fix, the LLVM PIC Assembler emitted an empty file when trying to assemble test/MC/PICMid/add.s. This silent error was caused by returning the wrong error code during operand parsing. This PR aims to rectify this issue.