### PR TITLE
PICMid Linker Support for LLD

### DIFF
--- a/lld/ELF/Arch/PICMid.cpp
+++ b/lld/ELF/Arch/PICMid.cpp
@@ -1,0 +1,80 @@
+#include "InputFiles.h"
+#include "Symbols.h"
+#include "Target.h"
+#include "lld/Common/ErrorHandler.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Support/Endian.h"
+
+using namespace llvm;
+using namespace llvm::object;
+using namespace llvm::support::endian;
+using namespace llvm::ELF;
+
+namespace lld {
+
+namespace elf {
+
+namespace {
+class PICMid final : public TargetInfo {
+public:
+  PICMid();
+  //   uint32_t calcEFlags() const override; // TODO: Handle
+  RelExpr getRelExpr(RelType type, const Symbol &s,
+                     const uint8_t *loc) const override;
+
+  void relocate(uint8_t *loc, const Relocation &rel,
+                uint64_t val) const override;
+};
+
+} // namespace
+
+PICMid::PICMid() {
+  defaultMaxPageSize = 4;
+  defaultCommonPageSize = 4;
+}
+
+RelExpr PICMid::getRelExpr(RelType type, const Symbol &s,
+                           const uint8_t *loc) const {
+  switch (type) {
+  default:
+    return R_ABS;
+  }
+}
+
+void PICMid::relocate(uint8_t *loc, const Relocation &rel, uint64_t val) const {
+  uint64_t pcAddr;
+  switch (rel.type) {
+  case R_PICMID_IMM8:
+    checkIntUInt(loc, val, 8, rel);
+    *loc = static_cast<unsigned char>(val);
+    break;
+  case R_PICMID_ADDR7:
+    checkUInt(loc, val, 7, rel);
+    *loc &= ~0x7F;
+    *loc |= static_cast<unsigned char>(val);
+    break;
+  case R_PICMID_PCABS11:
+    assert(val % 2 == 0 &&
+           "Program memory address in bytes must be evenly divisible by 2");
+    pcAddr = val / 2;
+    checkUInt(loc, pcAddr, 11, rel);
+    write16le(loc, (read16le(loc) & ~0x07FF) | (pcAddr & 0x07FF));
+    break;
+  default:
+  case R_PICMID_IMM1:
+  case R_PICMID_IMM3:
+    error(getErrorLocation(loc) + "unrecognized relocation " +
+          toString(rel.type));
+    break;
+  }
+}
+
+TargetInfo *getPICMidTargetInfo() {
+  static PICMid target;
+  return &target;
+}
+
+} // namespace elf
+
+} // namespace lld

--- a/lld/ELF/CMakeLists.txt
+++ b/lld/ELF/CMakeLists.txt
@@ -29,6 +29,7 @@ add_lld_library(lldELF
   Arch/Mips.cpp
   Arch/MipsArchTree.cpp
   Arch/MSP430.cpp
+  Arch/PiCMid.cpp
   Arch/PPC.cpp
   Arch/PPC64.cpp
   Arch/RISCV.cpp

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -184,6 +184,7 @@ static std::tuple<ELFKind, uint16_t, uint8_t> parseEmulation(StringRef emul) {
           .Case("elf64btsmip", {ELF64BEKind, EM_MIPS})
           .Case("elf64ltsmip", {ELF64LEKind, EM_MIPS})
           .Case("elf64lriscv", {ELF64LEKind, EM_RISCV})
+          .Case("elf_picmid", {ELF32LEKind, EM_MCHP_PIC})
           .Case("elf64ppc", {ELF64BEKind, EM_PPC64})
           .Case("elf64lppc", {ELF64LEKind, EM_PPC64})
           .Cases("elf_amd64", "elf_x86_64", {ELF64LEKind, EM_X86_64})
@@ -225,8 +226,8 @@ std::vector<std::pair<MemoryBufferRef, uint64_t>> static getArchiveMembers(
     v.push_back(std::make_pair(mbref, c.getChildOffset()));
   }
   if (err)
-    fatal(mb.getBufferIdentifier() + ": Archive::children failed: " +
-          toString(std::move(err)));
+    fatal(mb.getBufferIdentifier() +
+          ": Archive::children failed: " + toString(std::move(err)));
 
   // Take ownership of memory buffers created for members of thin archives.
   std::vector<std::unique_ptr<MemoryBuffer>> mbs = file->takeThinBuffers();
@@ -1165,7 +1166,8 @@ static void readConfigs(opt::InputArgList &args) {
       args.hasFlag(OPT_optimize_bb_jumps, OPT_no_optimize_bb_jumps, false);
   config->demangle = args.hasFlag(OPT_demangle, OPT_no_demangle, true);
   config->dependencyFile = args.getLastArgValue(OPT_dependency_file);
-  config->dependentLibraries = args.hasFlag(OPT_dependent_libraries, OPT_no_dependent_libraries, true);
+  config->dependentLibraries =
+      args.hasFlag(OPT_dependent_libraries, OPT_no_dependent_libraries, true);
   config->disableVerify = args.hasArg(OPT_disable_verify);
   config->discard = getDiscard(args);
   config->dwoDir = args.getLastArgValue(OPT_plugin_opt_dwo_dir_eq);
@@ -1190,8 +1192,8 @@ static void readConfigs(opt::InputArgList &args) {
       args.hasArg(OPT_shared);
   config->filterList = args::getStrings(args, OPT_filter);
   config->fini = args.getLastArgValue(OPT_fini, "_fini");
-  config->fixCortexA53Errata843419 = args.hasArg(OPT_fix_cortex_a53_843419) &&
-                                     !args.hasArg(OPT_relocatable);
+  config->fixCortexA53Errata843419 =
+      args.hasArg(OPT_fix_cortex_a53_843419) && !args.hasArg(OPT_relocatable);
   config->cmseImplib = args.hasArg(OPT_cmse_implib);
   config->cmseInputLib = args.getLastArgValue(OPT_in_implib);
   config->cmseOutputLib = args.getLastArgValue(OPT_out_implib);
@@ -1274,8 +1276,7 @@ static void readConfigs(opt::InputArgList &args) {
       args.hasFlag(OPT_print_gc_sections, OPT_no_print_gc_sections, false);
   config->printMemoryUsage = args.hasArg(OPT_print_memory_usage);
   config->printArchiveStats = args.getLastArgValue(OPT_print_archive_stats);
-  config->printSymbolOrder =
-      args.getLastArgValue(OPT_print_symbol_order);
+  config->printSymbolOrder = args.getLastArgValue(OPT_print_symbol_order);
   config->relax = args.hasFlag(OPT_relax, OPT_no_relax, true);
   config->relaxGP = args.hasFlag(OPT_relax_gp, OPT_no_relax_gp, false);
   config->rpath = getRpath(args);
@@ -1301,7 +1302,8 @@ static void readConfigs(opt::InputArgList &args) {
   config->singleRoRx = !args.hasFlag(OPT_rosegment, OPT_no_rosegment, true);
   config->soName = args.getLastArgValue(OPT_soname);
   config->sortSection = getSortSection(args);
-  config->splitStackAdjustSize = args::getInteger(args, OPT_split_stack_adjust_size, 16384);
+  config->splitStackAdjustSize =
+      args::getInteger(args, OPT_split_stack_adjust_size, 16384);
   config->strip = getStrip(args);
   config->sysroot = args.getLastArgValue(OPT_sysroot);
   config->target1Rel = args.hasFlag(OPT_target1_rel, OPT_target1_abs, false);
@@ -1583,7 +1585,7 @@ static void readConfigs(opt::InputArgList &args) {
         getPackDynRelocs(args);
   }
 
-  if (auto *arg = args.getLastArg(OPT_symbol_ordering_file)){
+  if (auto *arg = args.getLastArg(OPT_symbol_ordering_file)) {
     if (args.hasArg(OPT_call_graph_ordering_file))
       error("--symbol-ordering-file and --call-graph-order-file "
             "may not be used together");
@@ -1695,10 +1697,9 @@ static void setConfigs(opt::InputArgList &args) {
   // enable the debug checks for all targets, but currently not all targets
   // have support for reading Elf_Rel addends, so we only enable for a subset.
 #ifndef NDEBUG
-  bool checkDynamicRelocsDefault = m == EM_AARCH64 || m == EM_ARM ||
-                                   m == EM_386 || m == EM_LOONGARCH ||
-                                   m == EM_MIPS || m == EM_RISCV ||
-                                   m == EM_X86_64;
+  bool checkDynamicRelocsDefault =
+      m == EM_AARCH64 || m == EM_ARM || m == EM_386 || m == EM_LOONGARCH ||
+      m == EM_MIPS || m == EM_RISCV || m == EM_X86_64;
 #else
   bool checkDynamicRelocsDefault = false;
 #endif
@@ -1826,7 +1827,8 @@ void LinkerDriver::createFiles(opt::InputArgList &args) {
         error("unbalanced --push-state/--pop-state");
         break;
       }
-      std::tie(config->asNeeded, config->isStatic, inWholeArchive) = stack.back();
+      std::tie(config->asNeeded, config->isStatic, inWholeArchive) =
+          stack.back();
       stack.pop_back();
       break;
     }
@@ -2929,11 +2931,13 @@ void LinkerDriver::link(opt::InputArgList &args) {
   if (!config->relocatable)
     ctx.inputSections.push_back(createCommentSection());
 
-  // Split SHF_MERGE and .eh_frame sections into pieces in preparation for garbage collection.
-  invokeELFT(splitSections,);
+  // Split SHF_MERGE and .eh_frame sections into pieces in preparation for
+  // garbage collection.
+  invokeELFT(splitSections, );
 
-  // Garbage collection and removal of shared symbols from unused shared objects.
-  invokeELFT(markLive,);
+  // Garbage collection and removal of shared symbols from unused shared
+  // objects.
+  invokeELFT(markLive, );
   demoteSharedAndLazySymbols();
 
   // Make copies of any input sections that need to be copied into each
@@ -2942,7 +2946,7 @@ void LinkerDriver::link(opt::InputArgList &args) {
 
   // Create synthesized sections such as .got and .plt. This is called before
   // processSectionCommands() so that they can be placed by SECTIONS commands.
-  invokeELFT(createSyntheticSections,);
+  invokeELFT(createSyntheticSections, );
 
   // Some input sections that are used for exception handling need to be moved
   // into synthetic sections. Do that now so that they aren't assigned to
@@ -2980,10 +2984,11 @@ void LinkerDriver::link(opt::InputArgList &args) {
   }
 
   // Two input sections with different output sections should not be folded.
-  // ICF runs after processSectionCommands() so that we know the output sections.
+  // ICF runs after processSectionCommands() so that we know the output
+  // sections.
   if (config->icf != ICFLevel::None) {
     invokeELFT(findKeepUniqueSections, args);
-    invokeELFT(doIcf,);
+    invokeELFT(doIcf, );
   }
 
   // Read the callgraph now that we know what was gced or icfed
@@ -2991,9 +2996,9 @@ void LinkerDriver::link(opt::InputArgList &args) {
     if (auto *arg = args.getLastArg(OPT_call_graph_ordering_file))
       if (std::optional<MemoryBufferRef> buffer = readFile(arg->getValue()))
         readCallGraph(*buffer);
-    invokeELFT(readCallGraphsFromObjectFiles,);
+    invokeELFT(readCallGraphsFromObjectFiles, );
   }
 
   // Write the result to the file.
-  invokeELFT(writeResult,);
+  invokeELFT(writeResult, );
 }

--- a/lld/ELF/InputFiles.cpp
+++ b/lld/ELF/InputFiles.cpp
@@ -1585,6 +1585,8 @@ static uint16_t getBitcodeMachineKind(StringRef path, const Triple &t) {
     return EM_MIPS;
   case Triple::msp430:
     return EM_MSP430;
+  case Triple::picmid: // TODO: Insert more PIC families
+    return EM_MCHP_PIC;
   case Triple::ppc:
   case Triple::ppcle:
     return EM_PPC;
@@ -1660,9 +1662,10 @@ static uint8_t mapVisibility(GlobalValue::VisibilityTypes gvVisibility) {
   llvm_unreachable("unknown visibility");
 }
 
-static void
-createBitcodeSymbol(Symbol *&sym, const std::vector<bool> &keptComdats,
-                    const lto::InputFile::Symbol &objSym, BitcodeFile &f) {
+static void createBitcodeSymbol(Symbol *&sym,
+                                const std::vector<bool> &keptComdats,
+                                const lto::InputFile::Symbol &objSym,
+                                BitcodeFile &f) {
   uint8_t binding = objSym.isWeak() ? STB_WEAK : STB_GLOBAL;
   uint8_t type = objSym.isTLS() ? STT_TLS : STT_NOTYPE;
   uint8_t visibility = mapVisibility(objSym.getVisibility());

--- a/lld/ELF/Target.cpp
+++ b/lld/ELF/Target.cpp
@@ -79,6 +79,8 @@ TargetInfo *elf::getTarget() {
     }
   case EM_MSP430:
     return getMSP430TargetInfo();
+  case EM_MCHP_PIC: // TODO: Extend to other PIC controller families
+    return getPICMidTargetInfo();
   case EM_PPC:
     return getPPCTargetInfo();
   case EM_PPC64:

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -82,8 +82,7 @@ public:
                                                 uint8_t stOther) const;
 
   // Return true if we can reach dst from src with RelType type.
-  virtual bool inBranchRange(RelType type, uint64_t src,
-                             uint64_t dst) const;
+  virtual bool inBranchRange(RelType type, uint64_t src, uint64_t dst) const;
 
   virtual void relocate(uint8_t *loc, const Relocation &rel,
                         uint64_t val) const = 0;
@@ -181,6 +180,7 @@ TargetInfo *getAVRTargetInfo();
 TargetInfo *getHexagonTargetInfo();
 TargetInfo *getLoongArchTargetInfo();
 TargetInfo *getMSP430TargetInfo();
+TargetInfo *getPICMidTargetInfo();
 TargetInfo *getPPC64TargetInfo();
 TargetInfo *getPPCTargetInfo();
 TargetInfo *getRISCVTargetInfo();

--- a/lld/test/ELF/picmid-pcabs11.s
+++ b/lld/test/ELF/picmid-pcabs11.s
@@ -1,0 +1,357 @@
+; REQUIRED: PICMid
+; RUN: rm -rf %t && split-file %s %t
+; RUN: llvm-mc -filetype=obj -triple=picmid %t/a.s -o %t/a.o
+; RUN: ld.lld -T %t/link.ld %t/a.o -o %t/a
+; RUN: llvm-objcopy -O ihex %t/a %t/a.hex
+; RUN: FileCheck %s --check-prefix=CHECK1 --input-file=%t/a.hex 
+
+
+; CHECK1:        :1000000000000000000000000000000000000000F0
+; CHECK1-NEXT:   :1000100000000000000000000000000000000000E0
+; CHECK1-NEXT:   :1000200000000000000000000000000000000000D0
+; CHECK1-NEXT:   :1000300000000000000000000000000000000000C0
+; CHECK1-NEXT:   :1000400000000000000000000000000000000000B0
+; CHECK1-NEXT:   :1000500000000000000000000000000000000000A0
+; CHECK1-NEXT:   :100060000000000000000000000000000000000090
+; CHECK1-NEXT:   :100070000000000000000000000000000000000080
+; CHECK1-NEXT:   :100080000000000000000000000000000000000070
+; CHECK1-NEXT:   :100090000000000000000000000000000000000060
+; CHECK1-NEXT:   :1000A0000000000000000000000000000000000050
+; CHECK1-NEXT:   :1000B0000000000000000000000000000000000040
+; CHECK1-NEXT:   :1000C0000000000000000000000000000000000030
+; CHECK1-NEXT:   :1000D0000000000000000000000000000000000020
+; CHECK1-NEXT:   :1000E0000000000000000000000000000000000010
+; CHECK1-NEXT:   :1000F0000000000000000000000000000000000000
+; CHECK1-NEXT:   :1001000000000000000000000000000000000000EF
+; CHECK1-NEXT:   :1001100000000000000000000000000000000000DF
+; CHECK1-NEXT:   :1001200000000000000000000000000000000000CF
+; CHECK1-NEXT:   :1001300000000000000000000000000000000000BF
+; CHECK1-NEXT:   :1001400000000000000000000000000000000000AF
+; CHECK1-NEXT:   :10015000000000000000000000000000000000009F
+; CHECK1-NEXT:   :10016000000000000000000000000000000000008F
+; CHECK1-NEXT:   :10017000000000000000000000000000000000007F
+; CHECK1-NEXT:   :10018000000000000000000000000000000000006F
+; CHECK1-NEXT:   :10019000000000000000000000000000000000005F
+; CHECK1-NEXT:   :1001A000000000000000000000000000000000004F
+; CHECK1-NEXT:   :1001B000000000000000000000000000000000003F
+; CHECK1-NEXT:   :1001C000000000000000000000000000000000002F
+; CHECK1-NEXT:   :1001D000000000000000000000000000000000001F
+; CHECK1-NEXT:   :1001E000000000000000000000000000000000000F
+; CHECK1-NEXT:   :1001F00000000000000000000000000000000000FF
+; CHECK1-NEXT:   :1002000000000000000000000000000000000000EE
+; CHECK1-NEXT:   :1002100000000000000000000000000000000000DE
+; CHECK1-NEXT:   :1002200000000000000000000000000000000000CE
+; CHECK1-NEXT:   :1002300000000000000000000000000000000000BE
+; CHECK1-NEXT:   :08024000803EC507202920299A
+; CHECK1-NEXT:   :00000001FF
+
+
+#--- link.ld
+
+SECTIONS
+{
+. = 0x0;
+.text : { *(.text) }
+. = 0x8000000;
+.data : { *(.data) }
+.bss : { *(.bss) }
+}
+
+#--- a.s
+
+    .globl _start;
+    .text
+_start:
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+what: ; Label at address 0x120
+    ADDLW 128
+    ADDWF 69, 1
+    GOTO what
+    GOTO what

--- a/llvm/lib/Target/PICMid/AsmParser/PICMidAsmParser.cpp
+++ b/llvm/lib/Target/PICMid/AsmParser/PICMidAsmParser.cpp
@@ -106,7 +106,7 @@ public:
 
   ParseStatus parseDirective(AsmToken DirectiveID) override {
     // TODO: Implement own asm directives
-    return ParseStatus{false};
+    return ParseStatus{ParseStatus::NoMatch};
   }
 
   bool parseRegister(MCRegister &Reg, SMLoc &StartLoc, SMLoc &EndLoc) override {

--- a/llvm/lib/Target/PICMid/MCTargetDesc/PICMidMCAsmBackend.cpp
+++ b/llvm/lib/Target/PICMid/MCTargetDesc/PICMidMCAsmBackend.cpp
@@ -90,19 +90,6 @@ bool PICMidMCAsmBackend::evaluateTargetFixup(const MCAssembler &Asm,
   const bool IsPCAbs11 = Fixup.getKind() == (MCFixupKind)PICMid::PCAbs11;
 
   assert(IsPCAbs11 && "unexpected target fixup kind");
-  bool IsResolved = false;
-
-  if (!Target.getSymB() && Target.getSymA()) {
-    const MCSymbolRefExpr *A = Target.getSymA();
-    const MCSymbol &SA = A->getSymbol();
-
-    if (A->getKind() == MCSymbolRefExpr::VK_None && SA.isDefined()) {
-      if (auto *Writer = Asm.getWriterPtr()) {
-        IsResolved = Writer->isSymbolRefDifferenceFullyResolvedImpl(
-            Asm, SA, *DF, false, false);
-      }
-    }
-  }
 
   Value = Target.getConstant();
   if (const MCSymbolRefExpr *A = Target.getSymA()) {
@@ -125,21 +112,22 @@ bool PICMidMCAsmBackend::evaluateTargetFixup(const MCAssembler &Asm,
          "Program memory address in bytes must be evenly divisible by 2");
   Value /= 2;
 
-  return IsResolved;
+  return false;
 }
 
 bool PICMidMCAsmBackend::fixupNeedsRelaxation(const MCFixup &Fixup,
                                               uint64_t Value,
                                               const MCRelaxableFragment *DF,
                                               const MCAsmLayout &Layout) const {
-  return true;
+  return false;
 }
 
 bool PICMidMCAsmBackend::fixupNeedsRelaxationAdvanced(
     const MCFixup &Fixup, bool Resolved, uint64_t Value,
     const MCRelaxableFragment *DF, const MCAsmLayout &Layout,
     const bool WasForced) const {
-  return Fixup.getKind() == (MCFixupKind)PICMid::PCAbs11;
+  //   return Fixup.getKind() == (MCFixupKind)PICMid::PCAbs11;
+  return false;
 }
 
 bool PICMidMCAsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,

--- a/llvm/lib/Target/PICMid/MCTargetDesc/PICMidMCAsmBackend.h
+++ b/llvm/lib/Target/PICMid/MCTargetDesc/PICMidMCAsmBackend.h
@@ -29,6 +29,17 @@ public:
                   uint64_t Value, bool IsResolved,
                   const MCSubtargetInfo *STI) const override;
 
+  /// Apply target-specific fixup, i.e., annotated with
+  /// MCFixupKindInfo::FKF_IsTarget
+  ///
+  /// FIXME:    In its current form, this function may be redundant.
+  ///           That's because it always returns false which is why
+  ///           Value is ignored.
+  /// TODO:     Decide, what to do with this function
+  ///
+  /// @return bool If true, fixup may be resolved prior to linking stage.
+  ///               In that case, the fixup is not listed as a relocation
+  ///               entry.
   bool evaluateTargetFixup(const MCAssembler &Asm, const MCAsmLayout &Layout,
                            const MCFixup &Fixup, const MCFragment *DF,
                            const MCValue &Target, uint64_t &Value,

--- a/llvm/test/MC/PICMid/jumpWithLabelRelocation.s
+++ b/llvm/test/MC/PICMid/jumpWithLabelRelocation.s
@@ -288,7 +288,7 @@
     nop
     nop
     nop
-what:
+what: ; Label at address 0x120
     ADDLW 128
     ADDWF 69, 1
-    goto what
+    GOTO what

--- a/llvm/test/MC/PICMid/jumpWithLabelRelocation.s
+++ b/llvm/test/MC/PICMid/jumpWithLabelRelocation.s
@@ -1,5 +1,8 @@
 ; RUN: llvm-mc -filetype=obj -triple=picmid %s -o -
 
+    .globl _start;
+    .text
+_start:
     nop
     nop
     nop
@@ -291,4 +294,5 @@
 what: ; Label at address 0x120
     ADDLW 128
     ADDWF 69, 1
+    GOTO what
     GOTO what

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -1161,6 +1161,7 @@ const EnumEntry<unsigned> ElfMachineType[] = {
   ENUM_ENT(EM_HUANY,         "Harvard Universitys's machine-independent object format"),
   ENUM_ENT(EM_PRISM,         "Vitesse Prism"),
   ENUM_ENT(EM_AVR,           "Atmel AVR 8-bit microcontroller"),
+  ENUM_ENT(EM_MCHP_PIC,      "Microchip 8-bit PIC(r) family"),
   ENUM_ENT(EM_FR30,          "Fujitsu FR30"),
   ENUM_ENT(EM_D10V,          "Mitsubishi D10V"),
   ENUM_ENT(EM_D30V,          "Mitsubishi D30V"),


### PR DESCRIPTION
Fixes #20. It does so by creating the necessary configs in LLD. Primarily, they tell LLD how to relocate a `PCAbs11` program memory address. Apart from that, it fixes some bugs such as:

# Target Machine Name

Previously, `llvm-readelf` displayed `cc` as the target machine of a PICMid ELF file. With this PR, it now displays ‘Microchip 8-bit PIC(r) family’.

# `PCAbs11` Relocation Entries

Inb4, (local) labels pointing to program memory were resolved prior to the linking stage. Thus, when the label they pointed to were relocated to another address, these absolute addresses were not adapted accordingly. Now, relocation entries are created for each `PCAbs11` label and resolved during the linking stage.

# Assembly Directives

Prior to this, assembly directives (which are inspired by GAS), e.g., `.globl`, were not correctly parsed by the `llvm-mc` assembler. With this, all GAS assembly directives are parsed correctly (hopefully).
