### PR TITLE
Provide fixes necessary to facilitate execution of CodeGen'd PICMid machine code

### DIFF
--- a/lld/test/ELF/picmid-pic16f883-blinky.s
+++ b/lld/test/ELF/picmid-pic16f883-blinky.s
@@ -1,0 +1,81 @@
+; REQUIRED: PICMid
+; RUN: rm -rf %t && split-file %s %t
+; RUN: llvm-mc -filetype=obj -triple=picmid %t/a.s -o %t/a.o
+; RUN: llvm-mc -filetype=obj -triple=picmid %t/config.s -o %t/config.o
+; RUN: ld.lld -T %t/link.ld %t/a.o %t/config.o -o %t/a
+; RUN: llvm-objcopy -O ihex %t/a %t/a.hex
+
+; TODO: Document "ax"
+; TODO: Use FileCheck
+; FIXME: The number of bytes stored inside the resulting intel hex file
+;           is always a multiple of 4. Should be 2. 
+
+#--- link.ld
+
+SECTIONS
+{
+.reset_vector 0x0000 : {
+    KEEP(*(.reset_vector))
+}
+
+. = 0x0010;
+.text : { *(.text) }
+.data : { *(.data) }
+.bss : { *(.bss) }
+
+.config1 0x4014 : { 
+    KEEP(*(.config1))
+}
+.config2 0x4016 : { 
+    KEEP(*(.config2)) 
+}
+
+}
+
+#--- a.s
+
+    .globl _start
+
+    .section .reset_vector,"ax",@progbits
+    goto _start
+
+    .text
+_start:
+;    BANKSEL PORTA
+;    CLRF    PORTA
+;    BANKSEL ANSEL
+;    CLRF    ANSEL
+;    BANKSEL TRISA
+;    MOVLW   0Ch
+;    MOVWF   TRISA
+;    # STATUS @ 0x03
+;    # PORTA @ 0x05
+;    # PORTC @ 0x07
+;    # ANSEL @ 0x188
+;    # TRISA @ 0x85
+;    # PORTC @ 0x87
+    BCF     0x03, 5 ; BANKSEL PORTC
+    BCF     0x03, 6
+    CLRF    0x07    ; CLRF PORTC
+    BSF     0x03, 5 ; BANKSEL ANSEL
+    BSF     0x03, 6
+    CLRF    0x08    ; CLRF ANSEL
+    BSF     0x03, 5 ; BANKSEL TRISC
+    BCF     0x03, 6
+    MOVLW   0x0C    ; MOVLW 0Ch
+    MOVWF   0x07
+    BCF     0x03, 5 ; BANKSEL PORTC
+    BCF     0x03, 6
+    BSF     0x07, 0  ; CLRF PORTC
+    BSF     0x07, 1  ; CLRF PORTC
+
+loop:
+    goto    loop
+
+
+#--- config.s
+
+    .section .config1,"ax",@progbits
+.byte   0x00, 0x00
+    .section .config2,"ax",@progbits
+.byte   0x00, 0x00

--- a/llvm/lib/Target/PICMid/PICMidInstrFormats.td
+++ b/llvm/lib/Target/PICMid/PICMidInstrFormats.td
@@ -146,7 +146,13 @@ class PICMidByteFileOp<string opcodestr, bits<6> opcode> : PICMidInst<opcodestr,
     let Inst{7} = d;
     let Inst{6-0} = f;
 }
-class PICMidByteFileOp_Other<string opcodestr, bits<6> opcode, bit d, AddressingMode mode> : PICMidInst<opcodestr, mode> {
+class PICMidByteFileOp_Address<string opcodestr, bits<6> opcode, bit d> : PICMidInst<opcodestr, Address> {
+    bits<7> f;
+    let Inst{13-8} = opcode;
+    let Inst{7} = d;
+    let Inst{6-0} = f;
+}
+class PICMidByteFileOp_Implicit<string opcodestr, bits<6> opcode, bit d> : PICMidInst<opcodestr, Implicit> {
     let Inst{13-8} = opcode;
     let Inst{7} = d;
     let Inst{6-0} = 0;

--- a/llvm/lib/Target/PICMid/PICMidInstrInfo.td
+++ b/llvm/lib/Target/PICMid/PICMidInstrInfo.td
@@ -5,8 +5,8 @@ include "PICMidInstrFormats.td"
 // BYTE-ORIENTED FILE REGISTER OPERATIONS
 def ADDWF : PICMidByteFileOp<"addwf", 0b000111>;
 def ANDWF : PICMidByteFileOp<"andwf", 0b000101>;
-def CLRF : PICMidByteFileOp_Other<"clrf", 0b000001, 0b1, Address>;
-def CLRW : PICMidByteFileOp_Other<"clrw", 0b000001, 0b1, Implicit>;
+def CLRF : PICMidByteFileOp_Address<"clrf", 0b000001, 0b1>;
+def CLRW : PICMidByteFileOp_Implicit<"clrw", 0b000001, 0b0>;
 def COMF : PICMidByteFileOp<"comf", 0b001001>;
 def DECF : PICMidByteFileOp<"decf", 0b000011>;
 def DECFSZ : PICMidByteFileOp<"decfsz", 0b001011>;
@@ -14,8 +14,8 @@ def INCF : PICMidByteFileOp<"incf", 0b001010>;
 def INCFSZ : PICMidByteFileOp<"incfsz", 0b001111>; 
 def IORWF : PICMidByteFileOp<"iorwf", 0b000100>; 
 def MOVF : PICMidByteFileOp<"movf", 0b001000>; 
-def MOVWF : PICMidByteFileOp_Other<"movwf", 0b000000, 0b1, Address>; 
-def NOP : PICMidByteFileOp_Other<"nop", 0b000000, 0b0, Implicit>; 
+def MOVWF : PICMidByteFileOp_Address<"movwf", 0b000000, 0b1>; 
+def NOP : PICMidByteFileOp_Implicit<"nop", 0b000000, 0b0>; 
 def RLF : PICMidByteFileOp<"rlf", 0b001101>; 
 def RRF : PICMidByteFileOp<"rrf", 0b001100>; 
 def SUBWF : PICMidByteFileOp<"subwf", 0b000010>; 


### PR DESCRIPTION
Fixes #17. Contains the following fixes:

# `CLRF`, `MOVWF`
Previously, constants passed to certain instructions were ignored, e.g., `CLRF`, `MOVWF`. Now, constants are correctly encoded

Issue #27 is left unfixed.