### PR TITLE
fix(PICMid): Duplicate getSubtargetImpl declaration

### DIFF
--- a/llvm/lib/Target/PICMid/PICMidTargetMachine.cpp
+++ b/llvm/lib/Target/PICMid/PICMidTargetMachine.cpp
@@ -104,11 +104,6 @@ llvm::PICMidTargetMachine::createPassConfig(PassManagerBase &PM) {
   return new PICMidPassConfig(*this, PM);
 }
 
-const TargetSubtargetInfo *
-llvm::PICMidTargetMachine::getSubtargetImpl(const Function &) const {
-  return &SubTarget;
-}
-
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializePICMidTarget() {
   RegisterTargetMachine<PICMidTargetMachine> X(getThePICMidTarget());
 

--- a/llvm/lib/Target/PICMid/PICMidTargetMachine.h
+++ b/llvm/lib/Target/PICMid/PICMidTargetMachine.h
@@ -29,8 +29,6 @@ public:
                       bool JIT);
 
   TargetPassConfig *createPassConfig(PassManagerBase &PM) override;
-  const TargetSubtargetInfo *getSubtargetImpl(const Function &) const override;
-
   TargetLoweringObjectFile *getObjFileLowering() const override {
     return TLOF.get();
   }


### PR DESCRIPTION
For some reason, the latest commits have caused a redefinition of [PICMidTargetMachine.getSubtargetImpl](https://github.com/llvm-pic/llvm-pic/blob/6340ad53a1ec49d8f14a3570ad90019b1441ae69/llvm/lib/Target/PICMid/PICMidTargetMachine.h#L32)

https://github.com/llvm-pic/llvm-pic/blob/6340ad53a1ec49d8f14a3570ad90019b1441ae69/llvm/lib/Target/PICMid/PICMidTargetMachine.h#L32

The above redefinition is removed with this PR.